### PR TITLE
feat(sc): add S3 logging Service Catalog product

### DIFF
--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -6,5 +6,20 @@ project:
   s3_bucket: brokentech-cfn
 
 tests:
-  default:
+  s3-log-bucket-with-default-parameters:
     template: ./templates/s3-logging.yaml
+
+  product-with-default-parameters:
+    template: ./templates/s3-logging-product.yaml
+    parameters:
+      TemplateUrlPrefix: https://$[taskcat_autobucket].s3.ca-central-1.amazonaws.com/s3-logging/
+
+  product-with-overriden-parameters:
+    template: ./templates/s3-logging-product.yaml
+    parameters:
+      Owner: taskcat-$[taskcat_random-string]
+      Distributor: taskcat-$[taskcat_random-string]
+      SupportUrl: http://taskcat-$[taskcat_random-string]
+      SupportDescription: taskcat-$[taskcat_random-string]
+      SupportEmail: taskcat@$[taskcat_random-string].test
+      TemplateUrlPrefix: https://$[taskcat_autobucket].s3.ca-central-1.amazonaws.com/s3-logging/

--- a/templates/s3-logging-product.yaml
+++ b/templates/s3-logging-product.yaml
@@ -1,0 +1,76 @@
+---
+Description: |
+  Service Catalog product to deploy a bucket for use with S3 server access
+  logging.
+
+Parameters:
+  Owner:
+    Type: String
+    Description: |
+      Service Catalog product owner.
+    Default: Shahrad Rezaei
+  Distributor:
+    Type: String
+    Description: |
+      Service Catalog product distributor.
+    Default: BrokenTech
+  SupportUrl:
+    Type: String
+    Description: |
+      URL for users to get support. Defaults to the GitHub repositories where
+      the CloudFormation templates are stored.
+    Default: https://github.com/ShahradR/s3-logging
+  SupportDescription:
+    Type: String
+    Default: |
+      To report any issues, please visit the project's GitHub repository and
+      open an issue.
+  SupportEmail:
+    Type: String
+    Default: shahrad@rezaei.io
+  TemplateUrlPrefix:
+    Type: String
+    Description: |
+      Prefix for the template URL. This should point to the S3 bucket where the
+      project is stored. This CloudFormation template will append
+      "templates/s3-logging.yaml" to the end of the value provided in this
+      parameter to create resources in other YAML files.
+
+Resources:
+  S3LoggingProduct:
+    Type: "AWS::ServiceCatalog::CloudFormationProduct"
+    Properties:
+      Name: Amazon S3 logging bucket
+      Description: |
+        Creates a bucket to use as a target for Amazon S3 server access logging.
+        When creating S3 buckets, reference this product when configuring server
+        access logging to have access information shipped over.
+
+        Because S3 bucket names are globally unique, and one such account needs
+        to exist in each AWS account, the bucket name will be appended with the
+        AWS account ID. Note that there are some security implications with
+        making the AWS account ID public. See https://bit.ly/2E9iThC for an
+        example of how the account ID could be manipulated to expose additional
+        information.
+      Owner:
+        Ref: Owner
+      Distributor:
+        Ref: Distributor
+      SupportDescription:
+        Ref: SupportDescription
+      SupportEmail:
+        Ref: SupportEmail
+      SupportUrl:
+        Ref: SupportUrl
+      AcceptLanguage: en
+      ProvisioningArtifactParameters:
+        - Info:
+            LoadTemplateFromURL:
+              Fn::Sub: "${TemplateUrlPrefix}templates/s3-logging.yaml"
+          Name: v1.0
+          Description: Baseline version
+
+Outputs:
+  ProductId:
+    Value:
+      Ref: S3LoggingProduct


### PR DESCRIPTION
Add a Service Catalog product to publish the S3 server access logging bucket.

To be used, the product needs to be made part of a Service Catalog portfolio. Because a portfolio can include many different products, this repository should be included as a Git submodule in another repo representing the overarching portfolio.

With the addition of new tests, the `default` test was also renamed to `s3-log-bucket-with-default-parameters`.